### PR TITLE
Mysql config

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,1 @@
+FLASK_APP=killawatt.py

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from config import Config
+from config import config
 from logging.handlers import RotatingFileHandler
 import logging
 import os
@@ -15,9 +15,10 @@ from app.extensions import debug_toolbar
 from app.models.user import User
 
 
-def create_app(config_class=Config):
+def create_app(config_class):
     app = Flask(__name__)
-    app.config.from_object(config_class)
+
+    app.config.from_object(config[config_class])
 
     ###################################################
     #### Init Extensions

--- a/app/models/address.py
+++ b/app/models/address.py
@@ -10,9 +10,9 @@ if TYPE_CHECKING:
 class Address(db.Model):
     __tablename__ = "address"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    street: Mapped[str] = mapped_column(String)
-    city: Mapped[str] = mapped_column(String)
-    state: Mapped[str] = mapped_column(String)
+    street: Mapped[str] = mapped_column(String(255))
+    city: Mapped[str] = mapped_column(String(255))
+    state: Mapped[str] = mapped_column(String(255))
     zip: Mapped[int] = mapped_column(Integer)
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id", ondelete="CASCADE"))
 

--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 class Customer(db.Model):
     __tablename__ = "customer"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    name: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
 
     addresses: Mapped[List["Address"]] = relationship("Address", back_populates="customer", cascade="all, delete")
     phone_numbers: Mapped[List["Telephone"]] = relationship("Telephone", back_populates="customer", cascade="all, delete")
@@ -36,7 +36,7 @@ class Telephone(db.Model):
 class Email(db.Model):
     __tablename__ = "email"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    email: Mapped[str] = mapped_column(String)
+    email: Mapped[str] = mapped_column(String(255))
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id", ondelete="CASCADE"))
 
     customer: Mapped["Customer"] = relationship("Customer", back_populates="emails")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -9,10 +9,10 @@ from app import db
 class User(UserMixin, db.Model):
     __tablename__ = "user"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    username: Mapped[str] = mapped_column(String(64), index=True, unique=True, nullable=False)
-    password: Mapped[str] = mapped_column(String, nullable=False)
-    email: Mapped[str] = mapped_column(String, index=True, unique=True)
-    security_permissions: Mapped[str] = mapped_column(String, default="Admin")  # TODO: make user types(i.e. Admin, Regular)
+    username: Mapped[str] = mapped_column(String(255), index=True, unique=True, nullable=False)
+    password: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), index=True, unique=True)
+    security_permissions: Mapped[str] = mapped_column(String(255), default="Admin")  # TODO: make user types(i.e. Admin, Regular)
     create_date: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     last_seen: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 

--- a/config.py
+++ b/config.py
@@ -14,8 +14,6 @@ class Config(object):
     PERMANENT_SESSION_LIFETIME = timedelta(minutes=30)
     REMEMBER_COOKIE_DURATION = timedelta(hours=24)
     DEBUG_TB_INTERCEPT_REDIRECTS = False
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI')\
-        or 'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO = False
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev'
@@ -23,7 +21,28 @@ class Config(object):
 
 
 class TestConfig(Config):
+    DEBUG = True
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'   # use an in-memory database for tests
     WTF_CSRF_ENABLED = False                # no CSRF during tests
     SESSION_FILE_THRESHOLD = 10
+
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI')\
+        or 'sqlite:///' + os.path.join(basedir, 'app.db')
+
+
+class ProductionConfig(Config):
+    DEBUG = False
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI')
+    SECRET_KEY = os.environ.get('SECRET_KEY')
+
+
+config = {
+    'development': DevelopmentConfig,
+    'production': ProductionConfig,
+    'testing': TestConfig,
+    'default': DevelopmentConfig
+}

--- a/killawatt.py
+++ b/killawatt.py
@@ -1,0 +1,17 @@
+import os
+from dotenv import load_dotenv
+from app import create_app
+
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+load_dotenv(os.path.join(basedir, '.env'))
+
+
+#################################################################################
+#### App Entry Point
+####
+#### Set config with a .env file placed in the root project directory.
+#### If no .env or environment variable set, default(DevelopmentConfig) is used.
+#### Example: FLASK_ENV=development
+#################################################################################
+app = create_app(os.getenv('FLASK_ENV') or 'default')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from app import create_app, db
 from app.models.user import User
 from app.models.customer import Customer, Telephone, Email
 from app.models.address import Address
-from config import TestConfig
 
 
 user1_pass = generate_password_hash("test")
@@ -14,7 +13,7 @@ user1_pass = generate_password_hash("test")
 def app():
     """Create and configure a new app instance for each test."""
     # Create the app with common test config
-    app = create_app(TestConfig)
+    app = create_app('testing')
 
     # Create the database and load test data
     # Set _password to pre-generated hashes, since hashing for each test is slow

--- a/tests/unit/tests.py
+++ b/tests/unit/tests.py
@@ -2,13 +2,12 @@
 import unittest
 from app import create_app, db
 from app.models.user import User
-from config import TestConfig
 from flask import current_app
 
 
 class UserAuthTest(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(TestConfig)
+        self.app = create_app('testing')
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.create_all()


### PR DESCRIPTION
App will now load a config class from config.py based on the FLASK_ENV environment variable set in a DotEnv(.env) file in the project root directory. If no .env file found or environment variable set, the app will load the 'default' config which is the DevelopmentConfig that will utilize a SQLite database that is saved locally and named "app.db". The DevelopmentConfig can use a MYSQL database by setting the environment variable DATABASE_URI in the .env file.
.env template can be found in the Google drive within the folder named "ENV Template" and will not be included in source control(GitHub).

killawatt.py is now the "entry point" of the app. No changes to how app is run from the command line i.e "flask run" or "flask run --debug".

Testing suite config setup changed to reflect how the app is now instantiated.

In the Models for the fields that are Strings, a length is now given, as Strings are converted to VARCHAR in MYSQL and those require a max length to be set. The length of 255 was chosen as that's the max length of a string allowed in MYSQL, and the actual user input length will be controlled on the frontend forms with validation.