### PR TITLE
Fixed current_user missing in navbar

### DIFF
--- a/app/customer/routes.py
+++ b/app/customer/routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, current_app, request, url_for, redirect, flash, session, jsonify
-from flask_login import login_required, current_user
+from flask_login import login_required
 from app import db
 from app.customer import bp
 from app.models.customer import Customer, Telephone, Email
@@ -25,7 +25,6 @@ def index():
     return render_template('customer/index.html.j2',
                            customers=customers,
                            endpoint=endpoint,
-                           username=current_user.username,
                            )
 
 
@@ -57,7 +56,6 @@ def add_customer():
     return render_template('customer/new_customer.html.j2',
                            form=form,
                            Customer=Customer,
-                           username=current_user.username,
                            )
 
 
@@ -81,7 +79,6 @@ def detail(Id):
     return render_template('customer/customer_navbar.html.j2',
                            customer=customer,
                            form=form,
-                           username=current_user.username,
                            )
 
 
@@ -138,5 +135,4 @@ def search():
     return render_template('customer/index.html.j2',
                            customers=customers,
                            endpoint=endpoint,
-                           username=current_user.username,
                            )

--- a/app/errors/routes.py
+++ b/app/errors/routes.py
@@ -1,5 +1,4 @@
 from flask import render_template
-from flask_login import current_user
 from app import db
 from app.errors import bp
 
@@ -7,7 +6,6 @@ from app.errors import bp
 @bp.app_errorhandler(404)
 def not_found_error(error):
     return render_template('errors/404.html.j2',
-                           username=current_user.username,
                            ), 404
 
 
@@ -15,5 +13,4 @@ def not_found_error(error):
 def internal_error(error):
     db.session.rollback()
     return render_template('errors/500.html.j2',
-                           username=current_user.username,
                            ), 500

--- a/app/home/routes.py
+++ b/app/home/routes.py
@@ -10,4 +10,6 @@ def index():
     else:
         current_user.username = "Guest"
 
-    return render_template('home/index.html.j2', username=current_user.username)
+    return render_template('home/index.html.j2',
+                           username=current_user.username,
+                           )

--- a/app/templates/includes/_navbar.html.j2
+++ b/app/templates/includes/_navbar.html.j2
@@ -25,7 +25,7 @@
           <div class="align-items-center">
             {% if current_user.is_authenticated %}
             <div class="nav-item d-none d-lg-inline pe-1">
-              {{ 'Logged in as: %s' % username.replace(current_user.username,"<b>{}</b>"
+              {{ 'Logged in as: %s' % current_user.username.replace(current_user.username,"<b>{}</b>"
                     .format(current_user.username)) |safe }}
             </div>
             <a class="nav-link nav-item d-lg-inline px-lg-1"

--- a/app/user_profile/routes.py
+++ b/app/user_profile/routes.py
@@ -17,4 +17,6 @@ def before_request():
 @login_required
 def user(username):
     user = db.one_or_404(db.select(User).filter_by(username=username))
-    return render_template('user_profile/user_profile.html.j2', user=user, username=current_user.username)
+    return render_template('user_profile/user_profile.html.j2',
+                           user=user,
+                           )


### PR DESCRIPTION
- current_user from flask-login is a global proxy to the logged-in user that is available in every template. I missed a spot in the navbar to add the current_user.
- Now every route doesn't require the username to be passed to the template, so I removed the usernames being passed into the templates that are no longer necessary.