### PR TITLE
Delete customer reload page logic

### DIFF
--- a/app/static/assets/js/main.js
+++ b/app/static/assets/js/main.js
@@ -126,11 +126,12 @@ $('#deleteBtnTD button').on('click', function () {
         .done(function(data) {
             if(data.status == '200 OK') {
                 $('#deleteCustomerModal').modal('hide');
-                if(rowIndex > 2 || currentPage == 1 || currentPage === undefined) {
-                    location.replace(document.location);
-                } else {
+                if(rowIndex == 2 && currentPage >= 2) {
                     location.replace(prevPageUrl);
-                };  
+                }
+                else {
+                    location.replace(document.location);
+                }; 
             };
         });
     });


### PR DESCRIPTION
- Deleting a customer will now correctly refresh the current page or go back to the previous page if there's no customer table rows left and there's more than one page available.