### PR TITLE
Customer summary close button fix

### DIFF
--- a/app/customer/routes.py
+++ b/app/customer/routes.py
@@ -12,6 +12,7 @@ from app.customer.forms import customerForm
 def index():
     # Reset search query.
     session.pop('search_tag', default=None)
+    session['thisRoutePrevPage'] = request.url
 
     page = request.args.get('page', 1, type=int)
     customers = db.paginate(db.select(Customer),
@@ -65,6 +66,7 @@ def add_customer():
 def detail(Id):
     form = customerForm()
     customer = db.get_or_404(Customer, Id)
+    thisRoutePrevPage = session.get('thisRoutePrevPage')
 
     if request.method == 'GET':
         # Pre-fill forms
@@ -79,6 +81,7 @@ def detail(Id):
     return render_template('customer/customer_navbar.html.j2',
                            customer=customer,
                            form=form,
+                           thisRoutePrevPage=thisRoutePrevPage,
                            )
 
 
@@ -117,6 +120,9 @@ def edit(Id):
 @bp.route('/search', methods=['POST', 'GET'])
 @login_required
 def search():
+    session['thisRoutePrevPage'] = request.url
+    thisRoutePrevPage = session.get('thisRoutePrevPage')
+
     if 'search_tag' in session and request.method != 'POST':
         search_tag = session['search_tag']  # Perist search item across pagination.
     else:
@@ -135,4 +141,5 @@ def search():
     return render_template('customer/index.html.j2',
                            customers=customers,
                            endpoint=endpoint,
+                           thisRoutePrevPage=thisRoutePrevPage,
                            )

--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING
-from typing import List
+from typing import TYPE_CHECKING, List
+from datetime import datetime, timezone
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy import Integer, String, ForeignKey
+from sqlalchemy import Integer, String, ForeignKey, DateTime
 from app import db
 
 if TYPE_CHECKING:
@@ -12,6 +12,7 @@ class Customer(db.Model):
     __tablename__ = "customer"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
+    create_date: Mapped[datetime] = mapped_column(DateTime, default=datetime.now(timezone.utc))
 
     addresses: Mapped[List["Address"]] = relationship("Address", back_populates="customer", cascade="all, delete")
     phone_numbers: Mapped[List["Telephone"]] = relationship("Telephone", back_populates="customer", cascade="all, delete")

--- a/app/static/assets/js/main.js
+++ b/app/static/assets/js/main.js
@@ -12,6 +12,7 @@ cancelButton = document.getElementById('closeButton');
 saveButton = document.getElementById('editButton');
 
 urlEditCustomer = $('#editButton').data('edit');
+thisRoutePrevPage = $('#closeButton').data('prev');
 
 $('#editButton').on('click', function(event) {
     event.stopPropagation();
@@ -40,7 +41,7 @@ $('#closeButton').on('click', function() {
             field.disabled = true;
         }
     } else {
-        history.back();
+        location.replace(thisRoutePrevPage);
     };
 });
 
@@ -131,7 +132,7 @@ $('#deleteBtnTD button').on('click', function () {
                 }
                 else {
                     location.replace(document.location);
-                }; 
+                };
             };
         });
     });
@@ -141,23 +142,22 @@ $('#deleteBtnTD button').on('click', function () {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Keep user input text in search field across pages.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-thisPageUrl = currentBaseUrl;
-if(!thisPageUrl.toLowerCase().includes('search')) {
-    sessionStorage.removeItem('text');
-};
-
-savedInputText = sessionStorage.getItem('text');
+if(!document.URL.match(/search/) && !document.URL.match(/customer\/\d+/)) {
+    sessionStorage.removeItem('searchText');
+}
+   
+savedInputText = sessionStorage.getItem('searchText');
 if(searchTagValue = document.getElementById('search_tag')) {
     searchTagValue.value = savedInputText;
 };
 
 $('#searchButton').on('click', function () {
     let inputText = document.getElementById('search_tag').value;
-    sessionStorage.setItem('text', inputText);
+    sessionStorage.setItem('searchText', inputText);
 });
 
 $('#resetSearchButton').on('click', function () {
-    sessionStorage.removeItem('text');
+    sessionStorage.removeItem('searchText');
 });
 
 

--- a/app/templates/customer/_summary.html.j2
+++ b/app/templates/customer/_summary.html.j2
@@ -42,13 +42,13 @@
     </div>
     {# End Row #}
     </div>
-
-    <div class="container text-center mt-5">
-        <button type="button" class="btn btn-primary" id="editButton" data-edit="{{ url_for('customer.edit', Id=customer.id)}}">Edit</button>
-        <button type="button" class="btn btn-primary" id="closeButton">Close</button>
-    </div>
 </form>
 
+<div class="container text-center mt-5">
+    <button type="button" class="btn btn-primary" id="editButton" form="editCustomerForm"
+        data-edit="{{ url_for('customer.edit', Id=customer.id)}}">Edit</button>
+    <button type="button" class="btn btn-primary" id="closeButton" data-prev="{{thisRoutePrevPage}}">Close</button>
+</div>
 
 {% endblock %}
 

--- a/app/templates/customer/_summary.html.j2
+++ b/app/templates/customer/_summary.html.j2
@@ -26,21 +26,33 @@
         </div>
         </div>
     </div>
-    {# Second card #}
+    <!-- Second card -->
     <div class="col-sm-6">
         <div class="card">
             <div class="card-header text-center">
                 <h5><b>Contact</b></h5>
             </div>
-        <div class="card-body">
-            <ul class="list-group list-group-flush">
-                <li class="list-group-item">{{ render_field(form.phone_number, maxlength="13", disabled="true")}}</li>
-                <li class="list-group-item">{{ render_field(form.email, disabled="true")}}</li>
-            </ul>
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">{{ render_field(form.phone_number, maxlength="13", disabled="true")}}</li>
+                    <li class="list-group-item">{{ render_field(form.email, disabled="true")}}</li>
+                </ul>
+            </div>
         </div>
+
+        <div class="card mt-3">
+            <div class="card-header text-center">
+                <h5><b>Created On</b></h5>
+            </div>
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">{{ moment(customer.create_date).format('LLL') }}</li>
+                </ul>
+            </div>
         </div>
+
     </div>
-    {# End Row #}
+    <!-- End Row -->
     </div>
 </form>
 


### PR DESCRIPTION
- Close button on customer summary page goes back to previous page the user was on and refreshes. Example: The user was on page 2 of the customer index table, clicked on view customer, edited the address, saved, clicked close button, The user then goes back to page 2 and sees the updated address in the table.
- Previous implementation of the close button would still go back to the previous page but wouldn't update the table information if the customer was edited. This was due to some odd behavior differences between Firefox and Chrome when utilizing the previous URL/history or the document.referrer of the HTTP header response that I wasn't able to figure out. A solution I used was to store the previous URL in the local storage of the session and refer to that within the close button and the JavaScript to go back.
- Added a create date column to the Customer model and to show the create date in the customer summary page.