### PR TITLE
Add extra phone and email

### DIFF
--- a/app/customer/forms.py
+++ b/app/customer/forms.py
@@ -15,6 +15,13 @@ def select_field_choices():
     return choices
 
 
+def select_to_add_choices():
+    choices = [("", ""),
+               ("otherPhone", "Other Phone"),
+               ("otherEmail", "Other Email")]
+    return choices
+
+
 class customerForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired()])
     street = StringField('Street', validators=[DataRequired()])
@@ -24,3 +31,9 @@ class customerForm(FlaskForm):
     phone_number = TelField('Phone Number', id='phoneNumber', validators=[DataRequired(), Length(min=13, max=13)])
     email = EmailField('Email', validators=[DataRequired(), Email()])
     submit = SubmitField('Submit', id='customerFormButton')
+
+
+class addContactInfoForm(FlaskForm):
+    select_to_add = SelectField('Create Contact', choices=select_to_add_choices())
+    other_phone_number = TelField('Other Phone', id='otherPhone', validators=[DataRequired(), Length(min=13, max=13)])
+    other_email = EmailField('Other Email', id="otherEmail", validators=[DataRequired(), Email()])

--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, List
 from datetime import datetime, timezone
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy import Integer, String, ForeignKey, DateTime
+from sqlalchemy import Integer, String, ForeignKey, DateTime, event
 from app import db
 
 if TYPE_CHECKING:
@@ -33,13 +33,6 @@ class Telephone(db.Model):
     def __repr__(self):
         return f"<Telephone id: {self.id!r}, phone_number: {self.phone_number!r}, customer_id: {self.customer_id!r}>"
 
-    # Strip paranthesis and dashes.
-    def format_set_phone_number(self, phone_num):
-        char_to_remove = ["(", ")", "-"]
-        for char in char_to_remove:
-            phone_num = phone_num.replace(char, "")
-        self.phone_number = phone_num
-
 
 class Email(db.Model):
     __tablename__ = "email"
@@ -51,3 +44,13 @@ class Email(db.Model):
 
     def __repr__(self):
         return f"<Email id: {self.id!r}, email: {self.email!r}, customer_id: {self.customer_id!r}>"
+
+
+# Strip paranthesis and dashes.
+@event.listens_for(Telephone.phone_number, 'set', retval=True)
+def format_phone_number(target, value, oldvalue, initiator):
+    if value is not None:
+        char_to_remove = ["(", ")", "-"]
+        for char in char_to_remove:
+            value = value.replace(char, "")
+    return value

--- a/app/static/assets/js/inputValidation.js
+++ b/app/static/assets/js/inputValidation.js
@@ -40,19 +40,24 @@ $('#registerForm, #loginForm, #admin-form').on('submit', function (event) {
 // Make sure length of phone number is 13 characters.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 function phoneNumberValidate() {
-    if(!document.getElementById('phoneNumber')) {
+    if(!document.getElementsByTagName('tel')) {
         return;
     }
 
-    const phoneNumValidate = document.getElementById('phoneNumber');
-    const isValid = phoneNumValidate.value.length === 13;
+    let isValid;
+    const typeTels = $('input[type="tel"]');
 
-    if(!isValid) {
-        phoneNumValidate.setCustomValidity('Invalid');
-        phoneNumValidate.nextElementSibling.textContent = 'Phone Number is too short.';
-    } else {
-        phoneNumValidate.setCustomValidity('');
-    };
+    for (const typeTel of typeTels) {
+        const phoneNumValidate = typeTel;
+        isValid = phoneNumValidate.value.length === 13;
+
+        if(!isValid) {
+            phoneNumValidate.setCustomValidity('Invalid');
+            phoneNumValidate.nextElementSibling.textContent = 'Phone Number is too short.';
+        } else {
+            phoneNumValidate.setCustomValidity('');
+        };
+    }
 
     return isValid;
 }
@@ -85,24 +90,27 @@ function usernameValidate() {
 // emailRegExp source: https://www.w3resource.com/javascript/form/email-validation.php
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 function emailValidate() {
-    if(!document.getElementById('email')) {
+    if(!document.getElementsByTagName('email')) {
         return;
     }
 
-    const email = document.getElementById('email');
+    let isValid;
+    const typeEmails = $('input[type="email"]');
 
     const emailRegExp =
     /^\w+([\.-\\+]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
 
-    const isValid = email.value.length === 0 || emailRegExp.test(email.value);
+    for(const typeEmail of typeEmails) {
+        const email = typeEmail;
+        isValid = email.value.length === 0 || emailRegExp.test(email.value);
 
-    if(!isValid) {
-        email.setCustomValidity('Invalid');
-        email.nextElementSibling.textContent = 'Not a valid email format';
-    } else {
-        email.setCustomValidity('');
-    };
-
+        if(!isValid) {
+            email.setCustomValidity('Invalid');
+            email.nextElementSibling.textContent = 'Not a valid email format';
+        } else {
+            email.setCustomValidity('');
+        };
+    }
     return isValid;
 }
 

--- a/app/static/assets/js/main.js
+++ b/app/static/assets/js/main.js
@@ -164,18 +164,20 @@ $('#resetSearchButton').on('click', function () {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Format phone number as user types: (XXX)XXX-XXXX
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-$('#phoneNumber').on('keyup change', function(event) {
+$(document).on('keyup change', 'input[type="tel"]', function(event) {
+    const typeTels = $('input[type="tel"]');
+    
+    for (const typeTel of typeTels) {
+        // '/\D/' Matches any character that is not a digit.
+        // 'g' global match modifier. Finds all matches not just the first.
+        let numKey = $(typeTel).val().replace(/\D/g,''); 
 
-    // '/\D/' Matches any character that is not a digit.
-    // 'g' global match modifier. Finds all matches not just the first.
-    let numKey = $(this).val().replace(/\D/g,''); 
-
-    // Do nothing if backspace, left and right arrow keys are pressed.
-    if(event.which != 8 && event.which != 37 && event.which != 39) {
-        $(this).val('(' + numKey.substring(0,3) + ')' + numKey.substring(3,6) + '-' + numKey.substring(6,10));
-    };
-
+        // Do nothing if backspace, left and right arrow keys are pressed.
+        if(event.which != 8 && event.which != 37 && event.which != 39) {
+            $(typeTel).val('(' + numKey.substring(0,3) + ')' + numKey.substring(3,6) + '-' + numKey.substring(6,10));
+        };
     phoneNumberValidate();
+    }
 });
 
 
@@ -183,9 +185,13 @@ $('#phoneNumber').on('keyup change', function(event) {
 // Format phone number when input field is pre-filled with data: (XXX)XXX-XXXX
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 (function () {
-    if(document.getElementById('phoneNumber')) {
-        const phoneNum = document.getElementById('phoneNumber').value;
-        const phoneNumFormatted = phoneNum.replace(/(\d{3})(\d{3})(\d{4})/, '($1)$2-$3');
-        document.getElementById('phoneNumber').value = phoneNumFormatted;
+    if(document.getElementsByTagName('tel')) {
+        const typeTels = $('input[type="tel"]');
+        for (const typeTel of typeTels) {
+            const phoneNum = typeTel.value;
+            const phoneNumFormatted = phoneNum.replace(/(\d{3})(\d{3})(\d{4})/, '($1)$2-$3');
+            typeTel.value = phoneNumFormatted;
+        }
     }
 })();
+

--- a/app/static/assets/js/main.js
+++ b/app/static/assets/js/main.js
@@ -20,6 +20,7 @@ $('#editButton').on('click', function(event) {
     $('#editButton').addClass('saveButton');
     $('#closeButton').addClass('cancelButton');
     $('#state').addClass('form-select');
+    $('#select_to_add').addClass('form-select');
     
     cancelButton.textContent = 'Cancel';
     saveButton.textContent = 'Save';
@@ -49,7 +50,7 @@ $('#closeButton').on('click', function() {
 $(document).on('click', '.saveButton', function(event) {
     event.preventDefault();
     let isValid = validateForm();
-
+    // TODO: Create function. if other_phone or other_email input field is empty disable validation and then delete from database and fields.
     if(isValid == true) {
         $.ajax({
             method: 'POST',
@@ -68,6 +69,83 @@ $(document).on('click', '.saveButton', function(event) {
             };
         });
     };
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Add email and phone input field on customer summary page
+////////////////////////////////////////////////////////////////////////////////////////////////////
+$(document).ready(function() {
+    // The dropdown field is only enabled after the edit button is clicked.
+    $('#select_to_add').on('change', function() {
+        let inputFieldName;
+        let inputFieldLabel;
+        let inputFieldID;
+        let inputFieldType;
+        let inputMaxLength = "255";
+        let inputMinLength = "";
+
+        let currentElement = document.getElementById('selectContact');
+
+        let newlistGroupItem = document.createElement('li');
+        $(newlistGroupItem).addClass('list-group-item');
+
+        selectElement = document.querySelector('#select_to_add');
+        inputFieldValue = selectElement.value;
+
+        if(inputFieldValue == "") {
+            return;
+        }
+
+        if(inputFieldValue == 'otherPhone') {
+            inputFieldName = "other_phone_number";
+            inputFieldID = "otherPhone";
+            inputFieldLabel = "Other Phone";
+            inputFieldType = "tel";
+            inputMaxLength = "13";
+            inputMinLength = "13";
+        } else {
+            inputFieldName = "other_email";
+            inputFieldID = "otherEmail";
+            inputFieldLabel = "Other Email";
+            inputFieldType = "email";
+        };
+
+        // Check if input field already exists
+        let existingInput = document.getElementById(inputFieldID);
+        if (existingInput) {
+            return;
+        }
+
+        $(currentElement).before(newlistGroupItem);
+        $(newlistGroupItem).prepend(
+            '<div class="row mb-3">' +
+                '<label for=' + `"${inputFieldValue}"` + 'class="col-sm-4 col-form-label">' + `${inputFieldLabel}` + '</label>' +
+                '<div class="col-sm-8">' +
+                    '<input id=' + `"${inputFieldID}"` +  'name=' + `"${inputFieldName}"` +
+                        'maxlength=' + `"${inputMaxLength}"` + 'minlength=' + `"${inputMinLength}"` +
+                        'type=' + `"${inputFieldType}"` + 'class="form-control" required>' +
+                    '</input>' +
+                    '<div class="invalid-feedback">' +
+                        'Please provide a valid.' + `${inputFieldValue}` +
+                    '</div>' +
+                '</div>' +
+            '</div>'
+        );
+
+        selectElement.value = ""; // After a selection is made reset the select field to be blank.
+        disableSelectOption(inputFieldValue); // Disable corresponding select option.
+    });
+
+    function disableSelectOption(value) {
+        $('#select_to_add option[value="' + value + '"]').prop('disabled', true);
+    }
+
+    // Disable select options on page load if corresponding input fields already exist
+    $('#editCustomerForm input').each(function() {
+        let inputFieldID = $(this).attr('id');
+        disableSelectOption(inputFieldID);
+    });
 });
 
 
@@ -194,4 +272,3 @@ $(document).on('keyup change', 'input[type="tel"]', function(event) {
         }
     }
 })();
-

--- a/app/templates/customer/_summary.html.j2
+++ b/app/templates/customer/_summary.html.j2
@@ -26,7 +26,7 @@
         </div>
         </div>
     </div>
-    <!-- Second card -->
+    {# Second card #}
     <div class="col-sm-6">
         <div class="card">
             <div class="card-header text-center">
@@ -36,6 +36,13 @@
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item">{{ render_field(form.phone_number, maxlength="13", disabled="true")}}</li>
                     <li class="list-group-item">{{ render_field(form.email, disabled="true")}}</li>
+                    {% if addContactForm.other_phone_number.data %}
+                    <li class="list-group-item">{{ render_field(addContactForm.other_phone_number, maxlength="13", disabled="true")}}</li>
+                    {% endif %}
+                    {% if addContactForm.other_email.data %}
+                    <li class="list-group-item">{{ render_field(addContactForm.other_email, disabled="true")}}</li>
+                    {% endif %}
+                    <li class="list-group-item" id="selectContact">{{ render_field(addContactForm.select_to_add, disabled="true")}}</li>
                 </ul>
             </div>
         </div>
@@ -52,7 +59,7 @@
         </div>
 
     </div>
-    <!-- End Row -->
+    {# End Row #}
     </div>
 </form>
 


### PR DESCRIPTION
- Event listener added to the phone_number attribute of the Telephone model. Will automatically format phone number when saved to the database without needing to call the format_and_set_phone method.
- Email and phone input field validations are now more generic by selecting by field tag type instead individual id's. So that multiple email/phone fields within a one form can be validated by the same function at the same time.
- A "Create Contact" dropdown menu in the customer summary page that is activated when the edit button is clicked, with the options of, "Other Phone" and "Other Email". When the user clicks an option a corresponding input field is created, and that option in the dropdown menu is disabled or if that field already exists, so that only one "Other Phone" and "Other Email" can be created per customer.