### PR TITLE
Delete other contact info

### DIFF
--- a/app/customer/forms.py
+++ b/app/customer/forms.py
@@ -3,7 +3,7 @@ from wtforms import StringField, SubmitField, TelField, SelectField, EmailField
 from wtforms.validators import DataRequired, Email, Length
 
 
-def select_field_choices():
+def select_field_choices_state():
     choices = [("", ""), ("AL", "AL"), ("AK", "AK"), ("AZ", "AZ"), ("AR", "AR"), ("CA", "CA"),
                ("CO", "CO"), ("CT", "CT"), ("DE", "DE"), ("DC", "DC"), ("FL", "FL"), ("GA", "GA"), ("HI", "HI"),
                ("ID", "ID"), ("IL", "IL"), ("IN", "IN"), ("IA", "IA"), ("KS", "KS"), ("KY", "KY"), ("LA", "LA"),
@@ -15,7 +15,7 @@ def select_field_choices():
     return choices
 
 
-def select_to_add_choices():
+def select_to_add_contact_choices():
     choices = [("", ""),
                ("otherPhone", "Other Phone"),
                ("otherEmail", "Other Email")]
@@ -26,14 +26,14 @@ class customerForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired()])
     street = StringField('Street', validators=[DataRequired()])
     city = StringField('City', validators=[DataRequired()])
-    state = SelectField('State', choices=select_field_choices(), validators=[DataRequired()])
+    state = SelectField('State', choices=select_field_choices_state(), validators=[DataRequired()])
     zip = StringField('Zip', validators=[DataRequired()])
-    phone_number = TelField('Phone Number', id='phoneNumber', validators=[DataRequired(), Length(min=13, max=13)])
+    phone_number = TelField('Phone Number', id='phoneNumber', name='Phone Number', validators=[DataRequired(), Length(min=13, max=13)])
     email = EmailField('Email', validators=[DataRequired(), Email()])
     submit = SubmitField('Submit', id='customerFormButton')
 
 
 class addContactInfoForm(FlaskForm):
-    select_to_add = SelectField('Create Contact', choices=select_to_add_choices())
-    other_phone_number = TelField('Other Phone', id='otherPhone', validators=[DataRequired(), Length(min=13, max=13)])
+    select_to_add = SelectField('Create Contact', choices=select_to_add_contact_choices())
+    other_phone_number = TelField('Other Phone', id='otherPhone', validators=[DataRequired(), Length(max=13)])
     other_email = EmailField('Other Email', id="otherEmail", validators=[DataRequired(), Email()])

--- a/app/customer/routes.py
+++ b/app/customer/routes.py
@@ -8,6 +8,9 @@ from app.models.address import Address
 from app.customer.forms import customerForm, addContactInfoForm
 
 
+##############################################################################################################
+#### Table Index View of All Customers
+##############################################################################################################
 @bp.route('/', methods=['GET', 'POST'])
 @login_required
 def index():
@@ -30,6 +33,9 @@ def index():
                            )
 
 
+##############################################################################################################
+#### Add Customer
+##############################################################################################################
 @bp.route('/add/', methods=['GET', 'POST'])
 @login_required
 def add_customer():
@@ -52,7 +58,7 @@ def add_customer():
         db.session.add(new_customer)
         db.session.commit()
         flash('New Customer Added')
-        return jsonify(status='200 OK')
+        return jsonify(status='200 OK', message='Customer add successful')
 
     return render_template('customer/new_customer.html.j2',
                            form=form,
@@ -60,7 +66,9 @@ def add_customer():
                            )
 
 
-# Customer detail view
+##############################################################################################################
+#### Customer Summary View
+##############################################################################################################
 @bp.route('/<int:Id>/', methods=['POST', 'GET'])
 @login_required
 def detail(Id):
@@ -83,28 +91,20 @@ def detail(Id):
         if (len(customer.emails) > 1):
             addContactForm.other_email.data = customer.emails[1].email
 
-    customer_create_date = format_date_local('', customer.create_date, '')
+        customer_create_date = format_date_local('', customer.create_date, '')
 
     return render_template('customer/customer_navbar.html.j2',
                            customer=customer,
                            form=form,
                            addContactForm=addContactForm,
                            thisRoutePrevPage=thisRoutePrevPage,
-                           customer_create_date=customer_create_date,
+                           customer_create_date=customer_create_date
                            )
 
 
-@bp.route('/<int:Id>/delete/', methods=['POST'])
-@login_required
-def delete_customer(Id):
-    customerID = db.get_or_404(Customer, Id)
-    db.session.delete(customerID)
-    db.session.commit()
-    flash('Customer deleted')
-    return jsonify(status='200 OK')
-
-
-# Edit route within the customer detail view
+##############################################################################################################
+#### Edit Customer - Also handles deletion of other contact info (otherPhone, otherEmail).
+##############################################################################################################
 @bp.route('/<int:Id>/edit/', methods=['POST'])
 @login_required
 def edit(Id):
@@ -113,34 +113,80 @@ def edit(Id):
     addContactForm = addContactInfoForm()
 
     if form.validate_on_submit():
-        customer.name = form.name.data
-        customer.addresses[0].street = form.street.data
-        customer.addresses[0].city = form.city.data
-        customer.addresses[0].state = form.state.data
-        customer.addresses[0].zip = form.zip.data
-        customer.phone_numbers[0].phone_number = form.phone_number.data
-        customer.emails[0].email = form.email.data
+        if customer.name != form.name.data:
+            customer.name = form.name.data
+        if customer.addresses[0].street != form.street.data:
+            customer.addresses[0].street = form.street.data
+        if customer.addresses[0].city != form.city.data:
+            customer.addresses[0].city = form.city.data
+        if customer.addresses[0].state != form.state.data:
+            customer.addresses[0].state = form.state.data
+        if customer.addresses[0].zip != form.zip.data:
+            customer.addresses[0].zip = form.zip.data
+        if customer.phone_numbers[0].phone_number != form.phone_number.data:
+            customer.phone_numbers[0].phone_number = form.phone_number.data
+        if customer.emails[0].email != form.email.data:
+            customer.emails[0].email = form.email.data
 
         # add/edit other_phone.
         if (len(customer.phone_numbers) <= 1 and request.form.get('other_phone_number')):
             addOtherPhone = Telephone(phone_number=request.form.get('other_phone_number'))
             customer.phone_numbers.append(addOtherPhone)
         if (len(customer.phone_numbers) > 1):
-            customer.phone_numbers[1].phone_number = addContactForm.other_phone_number.data
+            if customer.phone_numbers[1].phone_number != addContactForm.other_phone_number.data:
+                customer.phone_numbers[1].phone_number = addContactForm.other_phone_number.data
 
         # add/edit other_email.
-        if (len(customer.emails) > 1):
-            customer.emails[1].email = addContactForm.other_email.data
         if (len(customer.emails) <= 1 and request.form.get('other_email')):
             addOtherEmail = Email(email=request.form.get('other_email'))
             customer.emails.append(addOtherEmail)
+        if (len(customer.emails) > 1):
+            if customer.emails[1].email != addContactForm.other_email.data:
+                customer.emails[1].email = addContactForm.other_email.data
+
+        # Handle deletion of other contact info
+        if 'deleteOtherContactInfo' in request.form and request.form['deleteOtherContactInfo'] == 'true':
+            # Delete otherPhone or otherEmail.
+            if 'otherPhone' in request.form and len(customer.phone_numbers) > 1:
+                other_phone_to_delete = db.session.get(Telephone, customer.phone_numbers[1].id)
+                if other_phone_to_delete:
+                    db.session.delete(other_phone_to_delete)
+
+            if 'otherEmail' in request.form and len(customer.emails) > 1:
+                other_email_to_delete = db.session.get(Email, customer.emails[1].id)
+                if other_email_to_delete:
+                    db.session.delete(other_email_to_delete)
 
         db.session.add(customer)
         db.session.commit()
         flash('Your changes have been saved.')
-        return jsonify(status='200 OK')
+        return jsonify(status='200 OK', message='Customer edit successful')
+
+    # If form did not validate, return an error response
+    flash('Form validation failed. Your changes were not saved.')
+    return jsonify(status='400 Bad Request', error='Form validation failed')
 
 
+##############################################################################################################
+#### Delete Customer
+##############################################################################################################
+@bp.route('/<int:Id>/delete/', methods=['POST'])
+@login_required
+def delete_customer(Id):
+    customerID = db.get_or_404(Customer, Id)
+    if customerID:
+        db.session.delete(customerID)
+        db.session.commit()
+        flash('Customer deleted')
+        return jsonify(status='200 OK', message='Customer deletion successful')
+
+    flash('Customer does not exist.')
+    return jsonify(status='400 Bad Request', message='Customer does not exist.')
+
+
+##############################################################################################################
+#### Search Customer
+##############################################################################################################
 @bp.route('/search', methods=['POST', 'GET'])
 @login_required
 def search():

--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 from datetime import datetime, timezone
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy import Integer, String, ForeignKey, DateTime, event
@@ -14,9 +14,9 @@ class Customer(db.Model):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     create_date: Mapped[datetime] = mapped_column(DateTime, default=datetime.now(timezone.utc))
 
-    addresses: Mapped[List["Address"]] = relationship("Address", back_populates="customer", cascade="all, delete")
-    phone_numbers: Mapped[List["Telephone"]] = relationship("Telephone", back_populates="customer", cascade="all, delete")
-    emails: Mapped[List["Email"]] = relationship("Email", back_populates="customer", cascade="all, delete")
+    addresses: Mapped[List["Address"]] = relationship("Address", back_populates="customer", cascade="all, delete-orphan")
+    phone_numbers: Mapped[List["Telephone"]] = relationship("Telephone", back_populates="customer", cascade="all, delete-orphan")
+    emails: Mapped[List["Email"]] = relationship("Email", back_populates="customer", cascade="all, delete-orphan")
 
     def __repr__(self):
         return f"<Customer id: {self.id!r}, name: {self.name!r}>"
@@ -25,10 +25,10 @@ class Customer(db.Model):
 class Telephone(db.Model):
     __tablename__ = "telephone"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    phone_number: Mapped[str] = mapped_column(String(255))
+    phone_number: Mapped[Optional[str]] = mapped_column(String(255))
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id", ondelete="CASCADE"))
 
-    customer: Mapped["Customer"] = relationship("Customer", back_populates="phone_numbers")
+    customer: Mapped[Optional["Customer"]] = relationship("Customer", back_populates="phone_numbers")
 
     def __repr__(self):
         return f"<Telephone id: {self.id!r}, phone_number: {self.phone_number!r}, customer_id: {self.customer_id!r}>"
@@ -37,10 +37,10 @@ class Telephone(db.Model):
 class Email(db.Model):
     __tablename__ = "email"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    email: Mapped[str] = mapped_column(String(255))
+    email: Mapped[Optional[str]] = mapped_column(String(255))
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id", ondelete="CASCADE"))
 
-    customer: Mapped["Customer"] = relationship("Customer", back_populates="emails")
+    customer: Mapped[Optional["Customer"]] = relationship("Customer", back_populates="emails")
 
     def __repr__(self):
         return f"<Email id: {self.id!r}, email: {self.email!r}, customer_id: {self.customer_id!r}>"

--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -25,10 +25,10 @@ class Customer(db.Model):
 class Telephone(db.Model):
     __tablename__ = "telephone"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    phone_number: Mapped[Optional[str]] = mapped_column(String(255))
+    phone_number: Mapped[str] = mapped_column(String(255))
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id", ondelete="CASCADE"))
 
-    customer: Mapped[Optional["Customer"]] = relationship("Customer", back_populates="phone_numbers")
+    customer: Mapped["Customer"] = relationship("Customer", back_populates="phone_numbers")
 
     def __repr__(self):
         return f"<Telephone id: {self.id!r}, phone_number: {self.phone_number!r}, customer_id: {self.customer_id!r}>"
@@ -37,10 +37,10 @@ class Telephone(db.Model):
 class Email(db.Model):
     __tablename__ = "email"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    email: Mapped[Optional[str]] = mapped_column(String(255))
+    email: Mapped[str] = mapped_column(String(255))
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id", ondelete="CASCADE"))
 
-    customer: Mapped[Optional["Customer"]] = relationship("Customer", back_populates="emails")
+    customer: Mapped["Customer"] = relationship("Customer", back_populates="emails")
 
     def __repr__(self):
         return f"<Email id: {self.id!r}, email: {self.email!r}, customer_id: {self.customer_id!r}>"

--- a/app/static/assets/js/inputValidation.js
+++ b/app/static/assets/js/inputValidation.js
@@ -12,15 +12,14 @@
         phoneNumberValidate();
         emailValidate();
         usernameValidate();
-
-        if(!form.checkValidity()) {
+    
+        if (!form.checkValidity()) {
             formValid = false;
-        };
+        }
         form.classList.add('was-validated');
     });
     return formValid;
 });
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Validate login and registration forms
@@ -40,27 +39,33 @@ $('#registerForm, #loginForm, #admin-form').on('submit', function (event) {
 // Make sure length of phone number is 13 characters.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 function phoneNumberValidate() {
-    if(!document.getElementsByTagName('tel')) {
-        return;
-    }
-
-    let isValid;
-    const typeTels = $('input[type="tel"]');
-
-    for (const typeTel of typeTels) {
-        const phoneNumValidate = typeTel;
-        isValid = phoneNumValidate.value.length === 13;
-
-        if(!isValid) {
-            phoneNumValidate.setCustomValidity('Invalid');
-            phoneNumValidate.nextElementSibling.textContent = 'Phone Number is too short.';
+    let otherPhoneInput = document.getElementById('otherPhone');
+    if (otherPhoneInput) {
+        let phoneNumber = otherPhoneInput.value.trim();
+        let phoneRegex = /^\(\d{3}\)\d{3}-\d{4}$/;
+        
+        if (!phoneRegex.test(phoneNumber) && phoneNumber !== '') {
+            otherPhoneInput.setCustomValidity("Invalid");
+            otherPhoneInput.nextElementSibling.textContent = 'Phone Number is too short.'
         } else {
-            phoneNumValidate.setCustomValidity('');
-        };
-    }
+            otherPhoneInput.setCustomValidity('');
+        }
+    };
 
-    return isValid;
+    // Check all other tel inputs
+    let telInputs = document.querySelectorAll('input[type="tel"]');
+    telInputs.forEach(input => {
+        if (input.id !== 'otherPhone') {
+            if(input.value.trim().length !== 13) {
+                input.setCustomValidity('Invalid');
+                input.nextElementSibling.textContent = 'Phone Number is too short.'
+            } else {
+                input.setCustomValidity('');
+            }
+        };
+    });
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Make sure length of the username is at least 2 characters.
@@ -68,7 +73,7 @@ function phoneNumberValidate() {
 function usernameValidate() {
     if(!document.getElementById('username')) {
         return;
-    }
+    };
 
     const username = document.getElementById('username');
     const minLength = 2;
@@ -92,7 +97,7 @@ function usernameValidate() {
 function emailValidate() {
     if(!document.getElementsByTagName('email')) {
         return;
-    }
+    };
 
     let isValid;
     const typeEmails = $('input[type="email"]');

--- a/app/templates/customer/_summary.html.j2
+++ b/app/templates/customer/_summary.html.j2
@@ -8,41 +8,21 @@
 </div>
 
 
-<form action="" method="POST" class="needs-validation" id="editCustomerForm" novalidate>
-    <div class="row mt-5">
+
+<div class="row mt-5">
     <div class="col-sm-6 mb-3 mb-sm-0">
+        <form action="" method="POST" class="needs-validation" id="editCustomerForm" novalidate>
         <div class="card">
             <div class="card-header text-center">
                 <h5><b>Name & Address</b></h5>
             </div>
-        <div class="card-body">
-            <ul class="list-group list-group-flush">
-                <li class="list-group-item">{{ render_field(form.name, disabled="true")}}</li>
-                <li class="list-group-item">{{ render_field(form.street, disabled="true")}}</li>
-                <li class="list-group-item">{{ render_field(form.city, disabled="true")}}</li>
-                <li class="list-group-item">{{ render_field(form.state, disabled="true")}}</li>
-                <li class="list-group-item">{{ render_field(form.zip, disabled="true")}}</li>
-            </ul>
-        </div>
-        </div>
-    </div>
-    {# Second card #}
-    <div class="col-sm-6">
-        <div class="card">
-            <div class="card-header text-center">
-                <h5><b>Contact</b></h5>
-            </div>
-            <div class="card-body">
+            <div class="card-body py-1">
                 <ul class="list-group list-group-flush">
-                    <li class="list-group-item">{{ render_field(form.phone_number, maxlength="13", disabled="true")}}</li>
-                    <li class="list-group-item">{{ render_field(form.email, disabled="true")}}</li>
-                    {% if addContactForm.other_phone_number.data %}
-                    <li class="list-group-item">{{ render_field(addContactForm.other_phone_number, maxlength="13", disabled="true")}}</li>
-                    {% endif %}
-                    {% if addContactForm.other_email.data %}
-                    <li class="list-group-item">{{ render_field(addContactForm.other_email, disabled="true")}}</li>
-                    {% endif %}
-                    <li class="list-group-item" id="selectContact">{{ render_field(addContactForm.select_to_add, disabled="true")}}</li>
+                    <li class="list-group-item">{{ render_field(form.name, disabled="true")}}</li>
+                    <li class="list-group-item">{{ render_field(form.street, disabled="true")}}</li>
+                    <li class="list-group-item">{{ render_field(form.city, disabled="true")}}</li>
+                    <li class="list-group-item">{{ render_field(form.state, disabled="true")}}</li>
+                    <li class="list-group-item">{{ render_field(form.zip, disabled="true")}}</li>
                 </ul>
             </div>
         </div>
@@ -51,20 +31,60 @@
             <div class="card-header text-center">
                 <h5><b>Created On</b></h5>
             </div>
-            <div class="card-body">
+            <div class="card-body py-1">
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item">{{ customer_create_date }}</li>
                 </ul>
             </div>
         </div>
+    </div>
+
+    <!-- Second column -->
+    <div class="col-sm-6">
+        <div class="card">
+            <div class="card-header text-center">
+                <h5><b>Contact</b></h5>
+            </div>
+            <div class="card-body py-1">
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">
+                        {{ render_field(form.phone_number, maxlength="13", disabled="true")}}
+                    </li>
+                    <li class="list-group-item">{{ render_field(form.email, disabled="true")}}</li>
+                </ul>
+            </div>
+        </div>
+        </form>
+
+        <form action="" method="POST" class="needs-validation" id="otherCustomerForm" novalidate>
+        <div class="card mt-3">
+            <div class="card-header text-center">
+                <h5><b>Other Contact</b></h5>
+            </div>
+            <div class="card-body py-1">
+                <ul class="list-group list-group-flush" id="otherCustomerFormUL">
+                    {% if addContactForm.other_phone_number.data %}
+                    <li class="list-group-item">
+                        {{ render_field(addContactForm.other_phone_number, maxlength="13", disabled="true")}}
+                    </li>
+                    {% endif %}
+                    {% if addContactForm.other_email.data %}
+                    <li class="list-group-item">{{ render_field(addContactForm.other_email, disabled="true")}}</li>
+                    {% endif %}
+                    <li class="list-group-item" id="selectContact">
+                        {{ render_field(addContactForm.select_to_add, disabled="true")}}
+                    </li>
+                </ul>
+            </div>
+        </div>
+        </form>
 
     </div>
-    {# End Row #}
-    </div>
-</form>
+</div><!-- End of first row -->
+
 
 <div class="container text-center mt-5">
-    <button type="button" class="btn btn-primary" id="editButton" form="editCustomerForm"
+    <button type="button" class="btn btn-primary" id="editButton" form="editCustomerForm otherCustomerForm"
         data-edit="{{ url_for('customer.edit', Id=customer.id)}}">Edit</button>
     <button type="button" class="btn btn-primary" id="closeButton" data-prev="{{thisRoutePrevPage}}">Close</button>
 </div>

--- a/app/templates/includes/macros.html.j2
+++ b/app/templates/includes/macros.html.j2
@@ -1,6 +1,6 @@
 {# ADD / UPDATE FORMS #}
 {% macro render_field(field) %}
-    <div class="row mb-3">
+    <div class="row my-2">
         <label for="{{ field.name }}" class="col-sm-4 col-form-label">{{ field.label.text }} </label>
         <div class="col-sm-8">
             {{ field(class="form-control", **kwargs)|safe }}


### PR DESCRIPTION
- Reorganization of Customer route code. Moved the Delete route below the Edit route, so that the view customer route('<int:Id>/') and the Edit route are adjacent code wise as they heavily reference each other. Commented blocks between the routes for a better visual delineation between the routes.
- A better descriptive name for the field choice functions in the Customer Form for the dropdown menus(Select Fields).
- In the edit route, the data from the form will be checked against the current data in that customer model instance first, and if there are no changes do not overwrite that data.
- Telephone and Email Models now have the Optional attribute on the Customer relationship(the many side of the one to many relationship) so that they can be null and deleted. Change was done specifically for deleting Other Phone numbers and Other Email.
- The Other Phone and Other Email input fields of the customer summary page can now be removed if the field is empty. If there was previously data in those fields, and are saved in the database, when the save button is submitted and the input fields are empty those input fields will be removed and the Other Phone and Other Email will be deleted from the customer through the edit route.
- The phoneNumberValidate function now validates the Other Phone input field separately.
- The Other Contact info is now in its own bootstrap card and HTML form.
- The "Created On" bootstrap card in the customer summary page was moved below the address card.